### PR TITLE
[CBP-34466] Remove team and user mentions from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # code owners
-* @cbdutta
+* 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # code owners
-*  @SrimanPadmanabanCB @cbdutta
+* @cbdutta


### PR DESCRIPTION
## Changes

Removed team and individual user mentions from repos we don't own

### Details
- Removed @SrimanPadmanabanCB from CODEOWNERS